### PR TITLE
Add request body into non application/json post/put/delete requests

### DIFF
--- a/lib/moxinet/plug/mocked_response.ex
+++ b/lib/moxinet/plug/mocked_response.ex
@@ -77,13 +77,13 @@ defmodule Moxinet.Plug.MockedResponse do
           callback.(nil)
 
         _other ->
-          body = 
+          body =
             if json_body?(conn) do
               Jason.decode!(body)
             else
               body
             end
-          
+
           callback.(body)
       end
 

--- a/lib/moxinet/plug/mocked_response.ex
+++ b/lib/moxinet/plug/mocked_response.ex
@@ -77,8 +77,13 @@ defmodule Moxinet.Plug.MockedResponse do
           callback.(nil)
 
         _other ->
-          body = if json_body?(conn), do: Jason.decode!(body), else: nil
-          callback.(body)
+          if json_body?(conn) do
+            callback.(Jason.decode!(body))
+          else
+            # We still want to pass a request body to the expect function for other
+            # content types, for example application/x-www-form-urlencoded
+            callback.(body)
+          end
       end
 
     conn

--- a/lib/moxinet/plug/mocked_response.ex
+++ b/lib/moxinet/plug/mocked_response.ex
@@ -77,13 +77,14 @@ defmodule Moxinet.Plug.MockedResponse do
           callback.(nil)
 
         _other ->
-          if json_body?(conn) do
-            callback.(Jason.decode!(body))
-          else
-            # We still want to pass a request body to the expect function for other
-            # content types, for example application/x-www-form-urlencoded
-            callback.(body)
-          end
+          body = 
+            if json_body?(conn) do
+              Jason.decode!(body)
+            else
+              body
+            end
+          
+          callback.(body)
       end
 
     conn

--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -45,7 +45,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
 
       SignatureStorage.store(CustomAPIMock, :post, "/path", fn payload ->
         Kernel.send(test_pid, {:post_payload, payload})
-        %{status: 200, body: response_body}
+        %{status: 200, body: "test=yes"}
       end)
 
       _conn = MockedResponse.call(conn, @opts)

--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -37,10 +37,10 @@ defmodule Moxinet.Plug.MockedResponseTest do
     test "passes payload for non 'application/json' post requests" do
       test_pid = Kernel.self()
       _ = SignatureStorage.start_link(name: SignatureStorage)
-      response_body = "test=yes"
+      request_body = "test=yes"
 
       conn =
-        conn(:post, "/path")
+        conn(:post, "/path", request_body)
         |> put_req_header("x-moxinet-ref", Moxinet.pid_reference(self()))
 
       SignatureStorage.store(CustomAPIMock, :post, "/path", fn payload ->
@@ -51,7 +51,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
       _conn = MockedResponse.call(conn, @opts)
 
       assert_receive {:post_payload, payload}
-      refute payload == nil
+      assert payload == request_body
     end
 
     test "responds with a 500-error when no `x-moxinet-ref` header was defined" do

--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -34,7 +34,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
       assert conn.resp_body == Jason.encode!(response_body)
     end
 
-    test "Sends non nil payload for non 'application/json' post requests" do
+    test "passes payload for non 'application/json' post requests" do
       test_pid = Kernel.self()
       _ = SignatureStorage.start_link(name: SignatureStorage)
       response_body = "test=yes"

--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -39,7 +39,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
       _ = SignatureStorage.start_link(name: SignatureStorage)
 
       conn =
-        conn(:post, "/path", request_body)
+        conn(:post, "/path", "test=yes")
         |> put_req_header("x-moxinet-ref", Moxinet.pid_reference(self()))
 
       SignatureStorage.store(CustomAPIMock, :post, "/path", fn payload ->

--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -37,7 +37,6 @@ defmodule Moxinet.Plug.MockedResponseTest do
     test "passes payload for non 'application/json' post requests" do
       test_pid = Kernel.self()
       _ = SignatureStorage.start_link(name: SignatureStorage)
-      request_body = "test=yes"
 
       conn =
         conn(:post, "/path", request_body)
@@ -51,7 +50,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
       _conn = MockedResponse.call(conn, @opts)
 
       assert_receive {:post_payload, payload}
-      assert payload == request_body
+      assert payload == "test=yes"
     end
 
     test "responds with a 500-error when no `x-moxinet-ref` header was defined" do


### PR DESCRIPTION
The request body was not inserted into the callback function of the expect.
The current pull request sends the body of the request into the callback argument instead of nil