### PR TITLE
Allow callback to be a 2-arity function

### DIFF
--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -137,6 +137,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
       SignatureStorage.store(CustomAPIMock, :post, "/path", fn body, headers ->
         send(test_pid, {:body, body})
         send(test_pid, {:headers, headers})
+
         %{status: 200}
       end)
 


### PR DESCRIPTION
Background:
Seeing as moxinet currently doesn't expose the request headers
it's not possible to verify a certain set of headers being set in
a request, which is in many cases of value when wanting to verify
them being set as expected.

This change will allow the callback defined in moxinet to receive
another argument which contains the headers (excluding `x-moxinet-ref`).

It can now be used like this:

```elixir
test_pid = self()

MyMock.expect("/path", fn body, headers ->
  send(test_pid, {:body, body})
  send(test_pid, {:headers, headers})
end)

assert_receive {:body, "My body"}
assert_receive {:headers, [{"authorization", "Bearer xxx"}]}
```