### PR TITLE
Formalize expect callback response with `%Moxinet.Response{}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ end
 In tests, you can create rules for how your mocks should behave through `expect/4`:
 
 ```elixir
+alias Moxinet.Response
+
 describe "create_pr/1" do
   test "creates a pull request when" do
     GithubMock.expect(:post, "/pull-requests/123", fn _payload ->
-      %{status: 202, body: %{id: "pull-request-id"}}
+      %Response{status: 202, body: %{id: "pull-request-id"}}
     end)
 
     assert {:ok, %{status: 202, body: %{"id" => "pull-request-id"}}}} = GithubAPI.create_pr(title: "My PR")

--- a/lib/moxinet.ex
+++ b/lib/moxinet.ex
@@ -21,6 +21,9 @@ defmodule Moxinet do
     - `name`: Name of the moxinet supervisor. Defaults to `Moxinet`
 
   """
+
+  alias Moxinet.Response
+
   @spec start(Keyword.t()) :: {:ok, pid} | {:error, atom()}
   defdelegate start(opts), to: Moxinet.Application
 
@@ -54,7 +57,13 @@ defmodule Moxinet do
   Mocks a call for the passed module when used from a certain pid, defaulting `self()`
   """
   @type http_method :: :get | :post | :patch | :put | :delete | :options
-  @spec expect(module(), http_method, binary(), function(), pid) :: :ok
+  @type request_body :: String.t()
+  @type decoded_json_request_body :: %{String.t() => any()} | [any()]
+  @type header :: {String.t(), String.t()}
+  @type mock_function ::
+          (request_body() | decoded_json_request_body() -> Response.t())
+          | (request_body() | decoded_json_request_body(), [header()] -> Response.t())
+  @spec expect(module(), http_method, binary(), mock_function(), pid) :: :ok
   defdelegate expect(module, http_method, path, callback, from_pid \\ self()),
     to: Moxinet.SignatureStorage,
     as: :store

--- a/lib/moxinet/plug/mocked_response.ex
+++ b/lib/moxinet/plug/mocked_response.ex
@@ -3,6 +3,7 @@ defmodule Moxinet.Plug.MockedResponse do
 
   import Plug.Conn
 
+  alias Moxinet.Response
   alias Moxinet.SignatureStorage
 
   def init(opts) do
@@ -88,9 +89,6 @@ defmodule Moxinet.Plug.MockedResponse do
     |> put_response_body(response)
   end
 
-  defp moxinet_header?({"x-moxinet-ref", _}), do: true
-  defp moxinet_header?(_), do: false
-
   defp decode_decodable_body(%Plug.Conn{} = conn, body) do
     cond do
       body == "" -> nil
@@ -99,13 +97,14 @@ defmodule Moxinet.Plug.MockedResponse do
     end
   end
 
-  defp put_response_status(conn, response) do
-    Plug.Conn.put_status(conn, Map.get(response, :status, 200))
+  defp moxinet_header?({"x-moxinet-ref", _}), do: true
+  defp moxinet_header?(_), do: false
+
+  defp put_response_status(%Plug.Conn{} = conn, %Response{status: status}) do
+    Plug.Conn.put_status(conn, status)
   end
 
-  defp put_response_body(conn, response) do
-    body = Map.get(response, :body, "")
-
+  defp put_response_body(%Plug.Conn{} = conn, %Response{body: body}) do
     case get_req_header(conn, "accept") do
       ["application/json" | _] ->
         conn

--- a/lib/moxinet/response.ex
+++ b/lib/moxinet/response.ex
@@ -1,0 +1,12 @@
+defmodule Moxinet.Response do
+  @moduledoc """
+  A struct to define a response to return from the mock server.
+  """
+
+  @type t :: %__MODULE__{
+          status: 100..600,
+          body: binary() | map() | [any()]
+        }
+
+  defstruct status: 200, body: ""
+end

--- a/test/moxinet/mock_test.exs
+++ b/test/moxinet/mock_test.exs
@@ -3,6 +3,7 @@ defmodule Moxinet.MockTest do
   use Plug.Test
 
   alias Moxinet.SignatureStorage
+  alias Moxinet.Response
 
   setup_all do
     _ = SignatureStorage.start_link(name: SignatureStorage)
@@ -21,7 +22,12 @@ defmodule Moxinet.MockTest do
         |> put_req_header("x-moxinet-ref", Moxinet.pid_reference(self()))
 
       :ok =
-        MyMock.expect(:post, "/path", fn _payload -> %{status: 499, body: "My body"} end, self())
+        MyMock.expect(
+          :post,
+          "/path",
+          fn _payload -> %Response{status: 499, body: "My body"} end,
+          self()
+        )
 
       assert %Plug.Conn{status: 499, resp_body: "My body"} = MyMock.call(conn, [])
     end
@@ -35,7 +41,7 @@ defmodule Moxinet.MockTest do
         MyChildMock.expect(
           :post,
           "/path",
-          fn _payload -> %{status: 499, body: "My body"} end,
+          fn _payload -> %Response{status: 499, body: "My body"} end,
           self()
         )
 

--- a/test/moxinet/server_test.exs
+++ b/test/moxinet/server_test.exs
@@ -3,6 +3,7 @@ defmodule Moxinet.ServerTest do
   use Plug.Test
 
   alias Moxinet.SignatureStorage
+  alias Moxinet.Response
 
   describe "__using__/1" do
     test "creates a router that can forward requests to servers" do
@@ -19,14 +20,15 @@ defmodule Moxinet.ServerTest do
       _ = SignatureStorage.start_link(name: SignatureStorage)
 
       Mock.expect(:get, "/mocked_path", fn _payload ->
-        %{status: 418, body: "Hello world"}
+        %Response{status: 418, body: "Hello world"}
       end)
 
       conn =
         conn(:get, "/external_service/mocked_path")
         |> put_req_header("x-moxinet-ref", Moxinet.pid_reference(self()))
 
-      assert %{status: 418, resp_body: "Hello world"} = MockServer.call(conn, MockServer.init([]))
+      assert %Plug.Conn{status: 418, resp_body: "Hello world"} =
+               MockServer.call(conn, MockServer.init([]))
     end
   end
 end


### PR DESCRIPTION
Background:
It became appearant that the simple map, returned from an `expect/4` callback
wasn't enough to make an interface that was easy to grasp and limit potential mistakes.

This change will introduce `%Moxinet.Response{}`, which will be the expected return from all
callbacks sent to `Moxinet.expect/4`. With it, we'll get some help from the compiled by getting
compilation errors when trying to pass invalid fields and therefore make it easier to work with.