### PR TITLE
Raise error on unused expect

### DIFF
--- a/lib/moxinet.ex
+++ b/lib/moxinet.ex
@@ -67,4 +67,17 @@ defmodule Moxinet do
   defdelegate expect(module, http_method, path, callback, from_pid \\ self()),
     to: Moxinet.SignatureStorage,
     as: :store
+
+  @doc """
+  Verifies that all defined expectations have been called to prevent tests from
+  defining expectations that aren't used. Recommended usage is to set it up in
+  your test setup:
+
+  ```elixir
+  setup :verify_usage!    
+  ```
+  """
+  @spec verify_usage!(pid()) :: :ok | no_return()
+  defdelegate verify_usage!(test_pid, storage_pid \\ Moxinet.SignatureStorage),
+    to: Moxinet.SignatureStorage
 end

--- a/lib/moxinet/signature_storage/state.ex
+++ b/lib/moxinet/signature_storage/state.ex
@@ -57,4 +57,11 @@ defmodule Moxinet.SignatureStorage.State do
   def remove_monitor(%__MODULE__{monitors: monitors} = state, monitored_pid) do
     %{state | monitors: Map.drop(monitors, [monitored_pid])}
   end
+
+  def unused_signatures(%__MODULE__{signatures: signatures}, test_pid) do
+    Enum.filter(signatures, fn
+      {_signature, %Mock{owner: ^test_pid, used: times_used}} when times_used == 0 -> true
+      {_signature, _mock} -> false
+    end)
+  end
 end

--- a/lib/moxinet/unused_expectations_error.ex
+++ b/lib/moxinet/unused_expectations_error.ex
@@ -1,0 +1,14 @@
+defmodule Moxinet.UnusedExpectationsError do
+  defexception [:test_pid, :signatures]
+
+  def message(%__MODULE__{test_pid: test_pid, signatures: signatures}) do
+    """
+      test with pid `#{inspect(test_pid)}` did not use all expectations defined
+      with `Moxinet.expect/4`:
+
+      #{for {signature, _mock} <- signatures do
+      String.upcase(to_string(signature.method)) <> " " <> signature.path <> "\n"
+    end}
+    """
+  end
+end

--- a/test/moxinet/signature_storage_test.exs
+++ b/test/moxinet/signature_storage_test.exs
@@ -123,4 +123,37 @@ defmodule Moxinet.SignatureStorageTest do
                SignatureStorage.find_signature(__MODULE__, test_pid, method, path, storage_pid)
     end
   end
+
+  describe "verify_usage!/1" do
+    test "raises an error when signatures were defined but not used" do
+      {:ok, storage_pid} = SignatureStorage.start_link([])
+      method = :post
+      test_pid = self()
+      path = "/my-path"
+      callback = fn _, _ -> {:ok, []} end
+
+      :ok =
+        SignatureStorage.store(__MODULE__, method, path, callback, test_pid, storage_pid)
+
+      assert_raise Moxinet.UnusedExpectationsError, fn ->
+        SignatureStorage.verify_usage!(self(), storage_pid)
+      end
+    end
+
+    test "does not raise when all signatures was used" do
+      {:ok, storage_pid} = SignatureStorage.start_link([])
+      method = :post
+      test_pid = self()
+      path = "/my-path"
+      callback = fn _, _ -> {:ok, []} end
+
+      :ok =
+        SignatureStorage.store(__MODULE__, method, path, callback, test_pid, storage_pid)
+
+      assert {:ok, ^callback} =
+               SignatureStorage.find_signature(__MODULE__, test_pid, method, path, storage_pid)
+
+      assert :ok == SignatureStorage.verify_usage!(self(), storage_pid)
+    end
+  end
 end

--- a/test/moxinet/unused_expectations_error_test.exs
+++ b/test/moxinet/unused_expectations_error_test.exs
@@ -1,0 +1,22 @@
+defmodule Moxinet.UnusedExpectationsErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Moxinet.SignatureStorage.Mock
+  alias Moxinet.SignatureStorage.Signature
+  alias Moxinet.UnusedExpectationsError
+
+  describe "message/1" do
+    test "returns a valuable error" do
+      test_pid = self()
+
+      signatures = [
+        {%Signature{method: :get, path: "/get"}, %Mock{}},
+        {%Signature{method: :post, path: "/post"}, %Mock{}}
+      ]
+
+      error = %UnusedExpectationsError{test_pid: test_pid, signatures: signatures}
+
+      assert UnusedExpectationsError.message(error) =~ "GET /get\nPOST /post"
+    end
+  end
+end


### PR DESCRIPTION
Background:
Unused expectations can happen through copy-pasting or when code
does unexpected things. This means having some help with removing
unused expectations, or verifying that the ones that are defined, are
also used, will increase the overall health of a testsuite.

This change mainly adds the `verify_usage!` function, mean to be
used in a setup block to aid with giving guarantees.