### PR TITLE
Improve documentation structure and content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ Good news for everyone using `req`, moxinet can now be integrated seamlessly.
 
 Upgrade guide for `req` users:
 
-1. in `text.exs`, add the following `req` configuration:
+1. in `test.exs`, add the following `req` configuration:
 
 ```elixir
-# config/text.exs
+# config/test.exs
 config :req, default_options: [
   adapter: &Moxinet.ReqTestAdapter.run/1
 ]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ def deps do
 end
 ```
 
-### When using the `req` library, configure it to use `Moxinet.ReqTestAdapter` in yout `text.exs` file:
+### When using the `req` library, configure it to use `Moxinet.ReqTestAdapter` in your `test.exs` file:
 
 ```elixir
 # config/test.exs
@@ -93,7 +93,7 @@ In tests, you can create rules for how your mocks should behave through `expect/
 alias Moxinet.Response
 
 describe "create_pr/1" do
-  test "creates a pull request when" do
+  test "creates a pull request" do
     GithubMock.expect(:post, "/pull-requests/123", fn _payload ->
       %Response{status: 202, body: %{id: "pull-request-id"}, headers: [{"X-Rate-Limit", 10}]}
     end)
@@ -185,7 +185,7 @@ will absolutely do the job, but there are a few drawbacks:
 
 
 ## How it works
-`Moxinet` works a lot similar to `mox` except it'll focus on solving the same issue for HTTP request.
+`Moxinet` works very similarly to `mox` except it'll focus on solving the same issue for HTTP request.
 
 The test pid will be registered in the mock registry, where it can later be accessed from inside the mock.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ExUnit.start()
 
 ### 4. Configure your API urls
 
-Point your API at the mock server in the test environment:
+Point API urls at the mock server in the test environment:
 
 ```elixir
 # config/config.exs
@@ -73,7 +73,7 @@ config :my_app, GithubAPI,
 
 ### 5. Configure the `req` adapter (recommended)
 
-When using the `req` library, configure it to use `Moxinet.Adapters.ReqTestAdapter` in your `test.exs` file. This automatically injects the `x-moxinet-ref` header into all requests, so no manual header management is needed:
+With `req`, configure the adapter in `test.exs`. This automatically injects the `x-moxinet-ref` header into all requests — no manual header management needed:
 
 ```elixir
 # config/test.exs
@@ -142,7 +142,7 @@ Callbacks can be 1-arity (receives the request body) or 2-arity (receives the re
 
 ### `allow/2`
 
-By default, `$callers` propagation covers `Task` and most OTP processes automatically. For processes spawned with `spawn/1` or similar, explicitly grant access:
+`$callers` propagation covers `Task` and most OTP processes automatically. For plain `spawn/1`, explicitly grant access:
 
 ```elixir
 test "spawned process uses parent mocks" do
@@ -161,9 +161,9 @@ end
 
 ### `verify_usage!`
 
-All expectations must be consumed by the end of each test — unused expectations raise `Moxinet.UnusedExpectationsError`. This is checked automatically via an `on_exit` callback registered by `expect/4`.
+Unused expectations raise `Moxinet.UnusedExpectationsError` at the end of each test. This is checked automatically via an `on_exit` callback registered by `expect/4`.
 
-You can also verify explicitly:
+To verify explicitly:
 
 ```elixir
 setup :verify_usage!
@@ -180,9 +180,9 @@ setup :verify_usage!
 
 ## Using non-`req` HTTP clients
 
-When not using `req`, you must manually include the `x-moxinet-ref` header in your requests. Without it, Moxinet cannot match incoming requests to test processes.
+Without `req`, the `x-moxinet-ref` header must be added manually. Without it, Moxinet cannot match incoming requests to test processes.
 
-Use `Moxinet.build_mock_header/0` to get the header tuple. Only include this header in the test environment:
+Use `Moxinet.build_mock_header/0` to get the header tuple. Only include it in the test environment:
 
 ```elixir
 defmodule GithubAPI do
@@ -211,9 +211,9 @@ end
 
 ## Static fallbacks and plug composition
 
-The mock server is a Plug, so you can extend it like any other Plug.
+Mock modules are Plugs — extend them like any other.
 
-Define static catch-all routes alongside dynamic expectations. Static routes are matched after dynamic expectations — use this for responses that never vary across tests:
+Define static routes alongside dynamic expectations. Static routes match after dynamic expectations, so use them for responses that never vary across tests:
 
 ```elixir
 defmodule GithubMock do
@@ -238,7 +238,7 @@ end
 
 ## Why not `mox`?
 
-When testing calls to external servers, `mox` tends to guide you towards replacing the entire HTTP layer. A common pattern:
+When testing external HTTP calls, `mox` guides you towards replacing the entire HTTP layer. A common pattern:
 
 ```elixir
 defmodule GithubAPI do
@@ -263,16 +263,16 @@ end
 
 This works, but has drawbacks:
 
-1. The `HTTP` module remains untested since the test suite never exercises it
-2. HTTP client libraries (like Tesla) define headers, authentication, and JSON encoding — custom behavior that filters or encodes data can hide bugs. A `@derive {Jason, only: [...]}` can cause a bug that all tests miss because they verify data sent to the HTTP layer, not the wire
+1. The `HTTP` module remains untested — the test suite never exercises it
+2. HTTP client libraries (like Tesla) handle headers, authentication, and JSON encoding. Custom encoding logic can hide bugs — a `@derive {Jason, only: [...]}` can cause a production bug that all tests miss because they verify data sent to the HTTP layer, not the wire
 
-Moxinet fills those gaps while also reducing the need for behaviours and mocks.
+Moxinet fills those gaps while reducing the need for behaviours and mocks.
 
 ## How it works
 
-Moxinet works very similarly to `mox` except it focuses on HTTP requests.
+Moxinet works like `mox`, but for HTTP requests.
 
-The test pid is registered in the mock registry, where it can later be accessed from inside the mock.
+The test pid is registered in the mock registry. When a request arrives, the mock looks up the pid to find the matching expectation.
 
 ```mermaid
 flowchart TD

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 ![Hex.pm License](https://img.shields.io/hexpm/l/moxinet)
 
 # Moxinet
-Mocking server that, just like `mox`, allows parallel testing.
+
+HTTP mocking server for Elixir that supports parallel testing — like `mox`, but at the HTTP layer.
 
 HexDocs: https://hexdocs.pm/moxinet
 
 ## Installation
 
-Install the package by adding `moxinet` to your list of dependencies in `mix.exs`:
+Add `moxinet` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -19,19 +20,11 @@ def deps do
 end
 ```
 
-### When using the `req` library, configure it to use `Moxinet.ReqTestAdapter` in your `test.exs` file:
-
-```elixir
-# config/test.exs
-
-config :req, default_options: [
-  adapter: &Moxinet.Adapters.ReqTestAdapter.run/1
-]
-```
-
 ## Getting started
-To use `moxinet` you must first define your mock server, from which you'll forward
-mock-specific requests:
+
+### 1. Define a mock server
+
+The mock server is a Plug router that forwards requests to mock modules:
 
 ```elixir
 # test/support/mock_server.ex
@@ -43,7 +36,7 @@ defmodule MyApp.MockServer do
 end
 ```
 
-Then create the mock module (in this example `GithubMock`):
+### 2. Create a mock module
 
 ```elixir
 # test/support/mock_servers/github_mock.ex
@@ -53,7 +46,10 @@ defmodule GithubMock do
 end
 ```
 
-Start `moxinet` in your test helper (before `ExUnit.start()`)
+### 3. Start Moxinet in your test helper
+
+Moxinet must be started before `ExUnit.start()`:
+
 ```elixir
 # test/test_helper.exs
 {:ok, _} = Moxinet.start(port: 4040, router: MyApp.MockServer)
@@ -61,7 +57,9 @@ Start `moxinet` in your test helper (before `ExUnit.start()`)
 ExUnit.start()
 ```
 
-Let the API configuration decide whether the API should call the remote server or the local mock server:
+### 4. Configure your API urls
+
+Point your API at the mock server in the test environment:
 
 ```elixir
 # config/config.exs
@@ -73,21 +71,20 @@ config :my_app, GithubAPI,
   url: "http://localhost:4040/github"
 ```
 
----
+### 5. Configure the `req` adapter (recommended)
 
-If you're familiar with `plug`, you'll see that our mock server is indeed a plug and can therefore
-be extended like one.
-
-After you've added your server, mocks can be defined:
+When using the `req` library, configure it to use `Moxinet.Adapters.ReqTestAdapter` in your `test.exs` file. This automatically injects the `x-moxinet-ref` header into all requests, so no manual header management is needed:
 
 ```elixir
-# test/support/mocks/github_mock.ex
-defmodule GithubMock do
-  use Moxinet.Mock
-end
+# config/test.exs
+config :req, default_options: [
+  adapter: &Moxinet.Adapters.ReqTestAdapter.run/1
+]
 ```
 
-In tests, you can create rules for how your mocks should behave through `expect/4`:
+### 6. Write tests
+
+Use `expect/4` to define how your mocks should respond:
 
 ```elixir
 alias Moxinet.Response
@@ -112,12 +109,80 @@ describe "create_pr/1" do
 end
 ```
 
-**NOTE for requests not managed by `req`**: One small caveat with `moxinet` is that in order for us to be able to match
-a mock defined in a request with an incoming request, the requests must send the `x-moxinet-ref` header.
-Most HTTP libraries allows adding custom headers to your requests, but that might not always be the case.
+## Core concepts
 
-It's also not recommended to send the `x-moxinet-ref` header outside your test environment, meaning you'd
-likely want to do find a way to conditionally add it. Here is one example on how to achieve it in `req`:
+### `Moxinet.Response`
+
+Every `expect` callback must return a `%Moxinet.Response{}` struct:
+
+```elixir
+%Moxinet.Response{
+  status: 200,                          # required, integer 100-600
+  body: %{key: "value"},                # map, list, or binary (maps/lists are JSON-encoded)
+  headers: [{"X-Rate-Limit", "100"}]    # optional response headers
+}
+```
+
+The `Content-Type: application/json` header is added automatically when the body is a map or list.
+
+### `expect/4` options
+
+Pass options as the fifth argument:
+
+- `times:` — how many times the expectation can be matched (default: `1`)
+- `pid:` — the owning pid (default: `self()`)
+
+```elixir
+GithubMock.expect(:get, "/events", fn _body ->
+  %Moxinet.Response{status: 200, body: []}
+end, times: 3)
+```
+
+Callbacks can be 1-arity (receives the request body) or 2-arity (receives the request body and headers).
+
+### `allow/2`
+
+By default, `$callers` propagation covers `Task` and most OTP processes automatically. For processes spawned with `spawn/1` or similar, explicitly grant access:
+
+```elixir
+test "spawned process uses parent mocks" do
+  parent = self()
+
+  GithubMock.expect(:get, "/users", fn _ ->
+    %Moxinet.Response{status: 200, body: []}
+  end)
+
+  spawn(fn ->
+    Moxinet.allow(parent, self())
+    MyHTTPClient.get("/users")
+  end)
+end
+```
+
+### `verify_usage!`
+
+All expectations must be consumed by the end of each test — unused expectations raise `Moxinet.UnusedExpectationsError`. This is checked automatically via an `on_exit` callback registered by `expect/4`.
+
+You can also verify explicitly:
+
+```elixir
+setup :verify_usage!
+```
+
+### Error reference
+
+| Error | Cause |
+|---|---|
+| `Moxinet.MissingMockError` | No expectation registered for that pid/method/path |
+| `Moxinet.ExceededUsageLimitError` | Expectation called more times than its `times:` limit |
+| `Moxinet.InvalidReferenceError` | `x-moxinet-ref` header contained an unrecognised value |
+| `Moxinet.UnusedExpectationsError` | Test ended with expectations that were never called |
+
+## Using non-`req` HTTP clients
+
+When not using `req`, you must manually include the `x-moxinet-ref` header in your requests. Without it, Moxinet cannot match incoming requests to test processes.
+
+Use `Moxinet.build_mock_header/0` to get the header tuple. Only include this header in the test environment:
 
 ```elixir
 defmodule GithubAPI do
@@ -144,12 +209,36 @@ defmodule GithubAPI do
 end
 ```
 
-## Why not use `mox` instead?
-When testing calls to external servers `mox` tends to guide the user towards
-replacing the whole HTTP layer which is usually fine when the code is controlled
-by an external library, holding the responsibility of correctness on its own.
+## Static fallbacks and plug composition
 
-A commonly seen pattern where behaviors play the centric role like the following:
+The mock server is a Plug, so you can extend it like any other Plug.
+
+Define static catch-all routes alongside dynamic expectations. Static routes are matched after dynamic expectations — use this for responses that never vary across tests:
+
+```elixir
+defmodule GithubMock do
+  use Moxinet.Mock
+
+  get "/pull-requests/closed" do
+    send_resp(conn, 200, Jason.encode!([%{id: "1", closed: true}]))
+  end
+end
+```
+
+Compose with other plugs for shared verification logic:
+
+```elixir
+defmodule GithubMock do
+  use Moxinet.Mock
+
+  import Plug.BasicAuth
+  plug :basic_auth, username: "user", password: "s3cr3t"
+end
+```
+
+## Why not `mox`?
+
+When testing calls to external servers, `mox` tends to guide you towards replacing the entire HTTP layer. A common pattern:
 
 ```elixir
 defmodule GithubAPI do
@@ -172,22 +261,18 @@ defmodule GithubAPI do
 end
 ```
 
-will absolutely do the job, but there are a few drawbacks:
+This works, but has drawbacks:
 
-1. The `HTTP` remains untested as that is not being used by the test suite
-2. HTTP client libraries (like tesla) usually allow defining headers, authentication,
-   and in most cases also encodes passed data structures to JSON, where custom behavior
-   that filters/encodes data in certain ways can be included. I've seen cases where a
-   `@derive {Jason, only: [...]}` caused a bug that wasn't a bug according to all tests
-   that verified the expected data was sent to the HTTP layer.
+1. The `HTTP` module remains untested since the test suite never exercises it
+2. HTTP client libraries (like Tesla) define headers, authentication, and JSON encoding — custom behavior that filters or encodes data can hide bugs. A `@derive {Jason, only: [...]}` can cause a bug that all tests miss because they verify data sent to the HTTP layer, not the wire
 
-`moxinet` aims to fill those gaps while also reducing the need for behaviors and mocks
-
+Moxinet fills those gaps while also reducing the need for behaviours and mocks.
 
 ## How it works
-`Moxinet` works very similarly to `mox` except it'll focus on solving the same issue for HTTP request.
 
-The test pid will be registered in the mock registry, where it can later be accessed from inside the mock.
+Moxinet works very similarly to `mox` except it focuses on HTTP requests.
+
+The test pid is registered in the mock registry, where it can later be accessed from inside the mock.
 
 ```mermaid
 flowchart TD

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,0 +1,214 @@
+# Getting Started with Moxinet
+
+This guide walks through setting up Moxinet from scratch in a Phoenix application that calls the GitHub API using `req`.
+
+## Overview
+
+Moxinet is an HTTP mocking server. Instead of replacing your HTTP client with a behaviour and mock (like `mox`), Moxinet runs a local server that your application talks to in tests. This means your full HTTP stack — headers, encoding, authentication — is exercised in every test.
+
+## Step 1: Install Moxinet
+
+Add it to your test dependencies:
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:moxinet, "~> 0.7.0", only: :test}
+  ]
+end
+```
+
+Run `mix deps.get`.
+
+## Step 2: Create a mock server
+
+The mock server is a router that maps URL prefixes to mock modules. Each external service you call gets its own prefix:
+
+```elixir
+# test/support/mock_server.ex
+
+defmodule MyApp.MockServer do
+  use Moxinet.Server
+
+  forward("/github", to: MyApp.GithubMock)
+  forward("/stripe", to: MyApp.StripeMock)
+end
+```
+
+## Step 3: Create mock modules
+
+Each mock module handles requests for one external service:
+
+```elixir
+# test/support/mocks/github_mock.ex
+
+defmodule MyApp.GithubMock do
+  use Moxinet.Mock
+end
+```
+
+```elixir
+# test/support/mocks/stripe_mock.ex
+
+defmodule MyApp.StripeMock do
+  use Moxinet.Mock
+end
+```
+
+That's it — no callbacks or behaviours to define. Expectations are set per-test.
+
+## Step 4: Start Moxinet
+
+Add this to your test helper **before** `ExUnit.start()`:
+
+```elixir
+# test/test_helper.exs
+
+{:ok, _} = Moxinet.start(port: 4040, router: MyApp.MockServer)
+
+ExUnit.start()
+```
+
+## Step 5: Point your APIs at the mock server
+
+Assume your app has a GitHub API module that reads its base URL from config:
+
+```elixir
+# lib/my_app/github_api.ex
+
+defmodule MyApp.GithubAPI do
+  def create_pr(attrs) do
+    Req.post!(client(), url: "/pull-requests", json: attrs)
+  end
+
+  defp client do
+    Req.new(base_url: config()[:url])
+  end
+
+  defp config, do: Application.fetch_env!(:my_app, __MODULE__)
+end
+```
+
+In production, this hits the real GitHub API. In tests, point it at Moxinet:
+
+```elixir
+# config/config.exs
+config :my_app, MyApp.GithubAPI,
+  url: "https://api.github.com"
+
+# config/test.exs
+config :my_app, MyApp.GithubAPI,
+  url: "http://localhost:4040/github"
+```
+
+## Step 6: Configure the `req` adapter
+
+This is the recommended approach. It automatically injects the `x-moxinet-ref` header so Moxinet can match requests to test processes:
+
+```elixir
+# config/test.exs
+
+config :req, default_options: [
+  adapter: &Moxinet.Adapters.ReqTestAdapter.run/1
+]
+```
+
+> If you're not using `req`, see the [Non-req clients](#non-req-clients) section below.
+
+## Step 7: Write your first test
+
+```elixir
+defmodule MyApp.GithubAPITest do
+  use ExUnit.Case, async: true
+
+  alias Moxinet.Response
+
+  test "create_pr/1 returns the created pull request" do
+    MyApp.GithubMock.expect(:post, "/pull-requests", fn body ->
+      assert body["title"] == "My PR"
+
+      %Response{status: 201, body: %{id: "pr-123", title: "My PR"}}
+    end)
+
+    assert %{status: 201, body: %{"id" => "pr-123"}} =
+             MyApp.GithubAPI.create_pr(%{title: "My PR"})
+  end
+
+  test "create_pr/1 handles server errors" do
+    MyApp.GithubMock.expect(:post, "/pull-requests", fn _body ->
+      %Response{status: 500, body: %{message: "Internal Server Error"}}
+    end)
+
+    assert %{status: 500} = MyApp.GithubAPI.create_pr(%{title: "My PR"})
+  end
+end
+```
+
+Key things to notice:
+
+- **`async: true`** works out of the box — each test's expectations are scoped to its process
+- The callback receives the **decoded request body**, so you can assert on what your API module actually sent
+- Every expectation must be consumed — if a test defines a mock that never gets called, it fails with `UnusedExpectationsError`
+
+## Repeated expectations
+
+If code under test calls the same endpoint multiple times, use the `times` option:
+
+```elixir
+MyApp.GithubMock.expect(:get, "/rate-limit", fn _body ->
+  %Response{status: 200, body: %{remaining: 100}}
+end, times: 3)
+```
+
+## Spawned processes
+
+`Task` and most OTP processes inherit access automatically via `$callers`. For plain `spawn`, use `allow/2`:
+
+```elixir
+test "background job uses parent mocks" do
+  parent = self()
+
+  MyApp.GithubMock.expect(:get, "/users", fn _ ->
+    %Response{status: 200, body: []}
+  end)
+
+  spawn(fn ->
+    Moxinet.allow(parent, self())
+    MyApp.GithubAPI.list_users()
+  end)
+end
+```
+
+## Static fallbacks
+
+For responses that never change across tests, define them directly in the mock module. These are matched after dynamic expectations:
+
+```elixir
+defmodule MyApp.GithubMock do
+  use Moxinet.Mock
+
+  get "/status" do
+    send_resp(conn, 200, Jason.encode!(%{status: "ok"}))
+  end
+end
+```
+
+## Non-req clients
+
+Without the `req` adapter, you must manually add the `x-moxinet-ref` header. Use `Moxinet.build_mock_header/0` and only include it in the test environment:
+
+```elixir
+defmacrop add_moxinet_header(req) do
+  if Mix.env() == :test do
+    quote do
+      {name, value} = Moxinet.build_mock_header()
+      put_header(unquote(req), name, value)
+    end
+  else
+    quote do: unquote(req)
+  end
+end
+```
+
+Without this header, Moxinet cannot match requests to test processes and will raise `MissingMockError`.

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,10 @@ defmodule Moxinet.MixProject do
       aliases: aliases(),
       docs: [
         main: "readme",
-        extras: ["README.md"],
+        extras: ["README.md", "guides/getting-started.md"],
+        groups_for_extras: [
+          Guides: ~r/guides\/.*/
+        ],
         before_closing_head_tag: &before_closing_head_tag/1
       ],
       package: [


### PR DESCRIPTION
**Background:**
The README mixed setup instructions, rationale, and advanced usage into a single flow, making it hard to scan. Several APIs (`allow/2`, `verify_usage!`, `times`, error types) were undocumented in the README, and there were typos in both the README and CHANGELOG.

**Changes:**
- Fix typos in README (`yout text.exs`, incomplete test name, grammar) and CHANGELOG (`text.exs`)
- Restructure README into clear sections: install → setup steps → core concepts → advanced usage → rationale
- Document `allow/2`, `verify_usage!`, `times` option, and add an error reference table
- Add `guides/getting-started.md` as a HexDocs extra with a full walkthrough
- Tighten prose: remove hedging, consistent voice, shorter phrasing